### PR TITLE
extend ttl when client number more than allowed number

### DIFF
--- a/waitingroom/queue_access_controller_test.go
+++ b/waitingroom/queue_access_controller_test.go
@@ -29,6 +29,7 @@ func TestAccessController_Do(t *testing.T) {
 					Score:  1,
 				})
 				redisClient.SetEX(context.Background(), key+SuffixPermittedNo, "1", 3*time.Second)
+				redisClient.SetEX(context.Background(), key+SuffixCurrentNo, "1", 3*time.Second)
 			},
 			want: 1001,
 		},


### PR DESCRIPTION
許可待ちのクライアントが存在する状態で許可処理が実行された場合、TTLを延長する。